### PR TITLE
feat: add recent projects landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1098,12 +1098,6 @@
         "tailwindcss": "4.2.2"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
-      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
@@ -1403,12 +1397,6 @@
         "tailwindcss": "4.2.2"
       }
     },
-    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
-      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "license": "MIT"
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -1483,7 +1471,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2156,7 +2144,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {

--- a/src/composer/App.tsx
+++ b/src/composer/App.tsx
@@ -18,6 +18,7 @@ import SpecView from './SpecView';
 import ExportBar from './ExportBar';
 import DirectorPanel from './DirectorPanel';
 import ProjectPicker from './ProjectPicker';
+import LandingPage from './LandingPage';
 import { useProjectStore } from '../store/project';
 import { useSettingsStore } from '../store/settings';
 import { detectHardwareTier } from '../engine/profiler';
@@ -121,10 +122,7 @@ export default function App() {
                                 <Transport />
                             </>
                         ) : (
-                            <div className="empty-state">
-                                <p className="empty-state__icon">🎬</p>
-                                <p className="empty-state__text">Add images to start composing</p>
-                            </div>
+                            <LandingPage />
                         )}
                     </section>
 

--- a/src/composer/LandingPage.tsx
+++ b/src/composer/LandingPage.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+import { useProjectStore } from '../store/project';
+import { ProjectThumbnail } from './ProjectThumbnail';
+
+export default function LandingPage() {
+    const recentProjects = useProjectStore((s) => s.recentProjects);
+    const refreshProjectList = useProjectStore((s) => s.refreshProjectList);
+    const loadProjectById = useProjectStore((s) => s.loadProjectById);
+    const createNewProject = useProjectStore((s) => s.createNewProject);
+    const clearRecentProjects = useProjectStore((s) => s.clearRecentProjects);
+
+    useEffect(() => {
+        refreshProjectList();
+    }, [refreshProjectList]);
+
+    // limit to 8 recent projects, not including the "New Project" card
+    const displayProjects = recentProjects.slice(0, 8);
+
+    const handleClearAll = () => {
+        if (window.confirm('Delete ALL saved projects permanently? This cannot be undone.')) {
+            clearRecentProjects();
+        }
+    };
+
+    return (
+        <div className="landing-page">
+            <div className="landing-page__header">
+                <h2>Recent Projects</h2>
+                {recentProjects.length > 0 && (
+                    <button className="landing-page__clear-btn" onClick={handleClearAll} title="Permanently delete all projects">
+                        Clear all projects
+                    </button>
+                )}
+            </div>
+            <div className="landing-page__grid">
+                <div
+                    className="landing-page__card landing-page__card--new"
+                    onClick={createNewProject}
+                    data-testid="new-project-card"
+                >
+                    <div className="landing-page__card-thumb">
+                        <span>+</span>
+                    </div>
+                    <div className="landing-page__card-info">
+                        <h3>New Project</h3>
+                    </div>
+                </div>
+                {displayProjects.map((p) => (
+                    <div
+                        key={p.id}
+                        className="landing-page__card"
+                        onClick={() => loadProjectById(p.id)}
+                        data-testid="recent-project-card"
+                    >
+                        <div className="landing-page__card-thumb">
+                            {p.hasThumbnail ? (
+                                <ProjectThumbnail projectId={p.id} title={p.title} />
+                            ) : (
+                                <div className="landing-page__card-placeholder">🎬</div>
+                            )}
+                        </div>
+                        <div className="landing-page__card-info">
+                            <h3>{p.title}</h3>
+                            <p>{new Date(p.updatedAt).toLocaleDateString()}</p>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/composer/ProjectPicker.tsx
+++ b/src/composer/ProjectPicker.tsx
@@ -5,7 +5,7 @@
  * Also shows storage usage tip per the user's request.
  */
 
-import { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useProjectStore } from '../store/project';
 import { estimateStorageUsed, formatBytes } from '../store/persistence';
 
@@ -51,7 +51,7 @@ export default function ProjectPicker() {
         setIsOpen(false);
     };
 
-    const handleDelete = async (e: React.MouseEvent, id: string) => {
+    const handleDelete = async (e: React.MouseEvent<HTMLButtonElement>, id: string) => {
         e.stopPropagation();
         if (confirm('Delete this project? This cannot be undone.')) {
             await deleteProjectById(id);

--- a/src/composer/ProjectThumbnail.tsx
+++ b/src/composer/ProjectThumbnail.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { loadProjectThumbnail } from '../store/persistence';
+
+interface ProjectThumbnailProps {
+    projectId: string;
+    title: string;
+}
+
+export function ProjectThumbnail({ projectId, title }: ProjectThumbnailProps) {
+    const [url, setUrl] = useState<string | null>(null);
+
+    useEffect(() => {
+        let active = true;
+        let objectUrl: string | null = null;
+
+        loadProjectThumbnail(projectId).then((loadedUrl) => {
+            if (active && loadedUrl) {
+                objectUrl = loadedUrl;
+                setUrl(loadedUrl);
+            } else if (loadedUrl) {
+                // If unmounted before load finished, clean up immediately
+                URL.revokeObjectURL(loadedUrl);
+            }
+        });
+
+        return () => {
+            active = false;
+            if (objectUrl) {
+                URL.revokeObjectURL(objectUrl);
+            }
+        };
+    }, [projectId]);
+
+    if (!url) {
+        return <div className="landing-page__card-placeholder">🎬</div>;
+    }
+
+    return <img src={url} alt={title} />;
+}

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -36,6 +36,7 @@ export interface ProjectMeta {
     plateCount: number;
     createdAt: number;
     updatedAt: number;
+    hasThumbnail?: boolean;
 }
 
 // ─── DB setup ─────────────────────────────────────────────────────────────────
@@ -181,8 +182,22 @@ export async function listProjects(): Promise<ProjectMeta[]> {
             plateCount: p.spec.plates.length,
             createdAt: p.createdAt,
             updatedAt: p.updatedAt,
+            hasThumbnail: p.images && p.images.length > 0,
         }))
         .sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/**
+ * Loads just the first image of a project for thumbnail display.
+ */
+export async function loadProjectThumbnail(id: string): Promise<string | null> {
+    const db = await getDB();
+    const stored = (await db.get('projects', id)) as StoredProject | undefined;
+    if (!stored || !stored.images || stored.images.length === 0) return null;
+
+    const firstImg = stored.images[0];
+    const blob = new Blob([firstImg.buffer], { type: firstImg.type });
+    return URL.createObjectURL(blob);
 }
 
 /**
@@ -191,6 +206,14 @@ export async function listProjects(): Promise<ProjectMeta[]> {
 export async function deleteProject(id: string): Promise<void> {
     const db = await getDB();
     await db.delete('projects', id);
+}
+
+/**
+ * Clears all projects from IndexedDB.
+ */
+export async function clearAllProjects(): Promise<void> {
+    const db = await getDB();
+    await db.clear('projects');
 }
 
 // ─── App state ────────────────────────────────────────────────────────────────

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -17,6 +17,7 @@ import {
     getLastProjectId,
     listProjects as dbListProjects,
     deleteProject as dbDelete,
+    clearAllProjects as dbClearAll,
     type ProjectMeta,
 } from './persistence';
 
@@ -115,6 +116,7 @@ interface ProjectState {
     recentProjects: ProjectMeta[];
     refreshProjectList: () => Promise<void>;
     deleteProjectById: (id: string) => Promise<void>;
+    clearRecentProjects: () => Promise<void>;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -450,6 +452,16 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
             await get().refreshProjectList();
         } catch (err) {
             console.error('[MotionPlate] Failed to delete project:', err);
+        }
+    },
+
+    clearRecentProjects: async () => {
+        try {
+            await dbClearAll();
+            await get().refreshProjectList();
+            get().createNewProject();
+        } catch (err) {
+            console.error('[MotionPlate] Failed to clear projects:', err);
         }
     },
 }));

--- a/src/style.css
+++ b/src/style.css
@@ -522,6 +522,130 @@ input, select, textarea { font: inherit; color: inherit; background: none; borde
   transition: width .25s ease;
 }
 
+/* ── Landing Page (P5-11) ──────────────────────────────────────────────────── */
+
+.landing-page {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 32px;
+    background: var(--bg);
+    overflow-y: auto;
+}
+
+.landing-page__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.landing-page__header h2 {
+    font-size: 1.5rem;
+    font-weight: 500;
+    color: var(--text);
+    margin: 0;
+}
+
+.landing-page__clear-btn {
+    padding: 6px 12px;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: all 0.2s;
+}
+
+.landing-page__clear-btn:hover {
+    background: var(--surface);
+    color: var(--text);
+}
+
+.landing-page__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 20px;
+}
+
+.landing-page__card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    cursor: pointer;
+    transition: transform 0.2s, border-color 0.2s;
+    display: flex;
+    flex-direction: column;
+}
+
+.landing-page__card:hover {
+    transform: translateY(-2px);
+    border-color: var(--accent);
+}
+
+.landing-page__card-thumb {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background: var(--bg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.landing-page__card-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.landing-page__card-placeholder {
+    font-size: 2rem;
+    opacity: 0.5;
+}
+
+.landing-page__card-info {
+    padding: 12px;
+}
+
+.landing-page__card-info h3 {
+    margin: 0 0 4px 0;
+    font-size: 1rem;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.landing-page__card-info p {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+}
+
+.landing-page__card--new {
+    border-style: dashed;
+    background: transparent;
+}
+
+.landing-page__card--new:hover {
+    background: var(--surface);
+}
+
+.landing-page__card--new .landing-page__card-thumb {
+    background: transparent;
+    font-size: 3rem;
+    color: var(--text-dim);
+}
+
+.landing-page__card--new .landing-page__card-info h3 {
+    color: var(--text-dim);
+    text-align: center;
+}
+
 /* ── Empty state ───────────────────────────────────────────────────────────── */
 .empty-state {
   display: flex;

--- a/tests/composer/LandingPage.test.tsx
+++ b/tests/composer/LandingPage.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import LandingPage from '../../src/composer/LandingPage';
+import { useProjectStore } from '../../src/store/project';
+
+describe('LandingPage', () => {
+    let container: HTMLDivElement;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+
+        useProjectStore.setState({
+            recentProjects: [],
+            refreshProjectList: vi.fn(),
+            loadProjectById: vi.fn(),
+            createNewProject: vi.fn(),
+            clearRecentProjects: vi.fn(),
+        });
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('displays the New Project card always', async () => {
+        const root = createRoot(container);
+        root.render(<LandingPage />);
+        await new Promise(r => setTimeout(r, 0));
+
+        const newCard = document.querySelector('[data-testid="new-project-card"]');
+        expect(newCard).not.toBeNull();
+        expect(newCard?.textContent).toContain('New Project');
+
+        root.unmount();
+    });
+
+    it('displays up to 8 recent projects', async () => {
+        const mockProjects = Array.from({ length: 10 }, (_, i) => ({
+            id: `proj-${i}`,
+            title: `Project ${i}`,
+            plateCount: i,
+            createdAt: Date.now() - i * 1000,
+            updatedAt: Date.now() - i * 1000,
+            hasThumbnail: false,
+        }));
+
+        useProjectStore.setState({ recentProjects: mockProjects });
+
+        const root = createRoot(container);
+        root.render(<LandingPage />);
+        await new Promise(r => setTimeout(r, 0));
+
+        const projectCards = document.querySelectorAll('[data-testid="recent-project-card"]');
+        expect(projectCards.length).toBe(8);
+        expect(container.textContent).toContain('Project 0');
+        expect(container.textContent).toContain('Project 7');
+        expect(container.textContent).not.toContain('Project 8');
+
+        root.unmount();
+    });
+
+    it('calls loadProjectById when a project card is clicked', async () => {
+        const mockLoad = vi.fn();
+        const mockProjects = [
+            { id: 'proj-1', title: 'Test Project', plateCount: 1, createdAt: 0, updatedAt: 0 }
+        ];
+
+        useProjectStore.setState({
+            recentProjects: mockProjects,
+            loadProjectById: mockLoad
+        });
+
+        const root = createRoot(container);
+        root.render(<LandingPage />);
+        await new Promise(r => setTimeout(r, 0));
+
+        const card = document.querySelector('[data-testid="recent-project-card"]') as HTMLDivElement;
+        card.click();
+
+        expect(mockLoad).toHaveBeenCalledWith('proj-1');
+
+        root.unmount();
+    });
+
+    it('calls clearRecentProjects when Clear all projects button is clicked and confirmed', async () => {
+        const mockClear = vi.fn();
+        const mockProjects = [
+            { id: 'proj-1', title: 'Test Project', plateCount: 1, createdAt: 0, updatedAt: 0 }
+        ];
+
+        // Mock window.confirm to return true
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+        useProjectStore.setState({
+            recentProjects: mockProjects,
+            clearRecentProjects: mockClear
+        });
+
+        const root = createRoot(container);
+        root.render(<LandingPage />);
+        await new Promise(r => setTimeout(r, 0));
+
+        const buttons = document.querySelectorAll('button');
+        const clearBtn = Array.from(buttons).find(b => b.textContent?.includes('Clear all projects'));
+
+        expect(clearBtn).toBeDefined();
+        clearBtn!.click();
+
+        expect(confirmSpy).toHaveBeenCalledWith('Delete ALL saved projects permanently? This cannot be undone.');
+        expect(mockClear).toHaveBeenCalled();
+
+        confirmSpy.mockRestore();
+        root.unmount();
+    });
+
+    it('does not call clearRecentProjects when Clear all projects button is clicked but cancelled', async () => {
+        const mockClear = vi.fn();
+        const mockProjects = [
+            { id: 'proj-1', title: 'Test Project', plateCount: 1, createdAt: 0, updatedAt: 0 }
+        ];
+
+        // Mock window.confirm to return false
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+        useProjectStore.setState({
+            recentProjects: mockProjects,
+            clearRecentProjects: mockClear
+        });
+
+        const root = createRoot(container);
+        root.render(<LandingPage />);
+        await new Promise(r => setTimeout(r, 0));
+
+        const buttons = document.querySelectorAll('button');
+        const clearBtn = Array.from(buttons).find(b => b.textContent?.includes('Clear all projects'));
+
+        expect(clearBtn).toBeDefined();
+        clearBtn!.click();
+
+        expect(confirmSpy).toHaveBeenCalled();
+        expect(mockClear).not.toHaveBeenCalled();
+
+        confirmSpy.mockRestore();
+        root.unmount();
+    });
+
+    it('does not display clear button when there are no recent projects', async () => {
+        const root = createRoot(container);
+        root.render(<LandingPage />);
+        await new Promise(r => setTimeout(r, 0));
+
+        const buttons = document.querySelectorAll('button');
+        const clearBtn = Array.from(buttons).find(b => b.textContent?.includes('Clear all projects'));
+
+        expect(clearBtn).toBeUndefined();
+
+        root.unmount();
+    });
+
+    it('calls createNewProject when New Project card is clicked', async () => {
+        const mockCreate = vi.fn();
+        useProjectStore.setState({ createNewProject: mockCreate });
+
+        const root = createRoot(container);
+        root.render(<LandingPage />);
+        await new Promise(r => setTimeout(r, 0));
+
+        const newCard = document.querySelector('[data-testid="new-project-card"]') as HTMLDivElement;
+        newCard.click();
+
+        expect(mockCreate).toHaveBeenCalled();
+
+        root.unmount();
+    });
+});


### PR DESCRIPTION
This implements issue #13 (P5-11), which creates a landing page dashboard for users to quickly resume work on recently saved projects or create a new one.

Key features:
- Adds a `LandingPage` component that replaces the `empty-state` in the center panel when there are no plates.
- Shows up to 8 recent projects, sorted by `updatedAt` descending.
- Safely manages `URL.createObjectURL` object lifecycle for thumbnails via `ProjectThumbnail` to prevent memory leaks.
- Adds a "Clear all projects" button with a confirmation dialog to safely wipe IndexedDB.
- Provides test coverage ensuring the UI renders and interacts correctly with the store.

---
*PR created automatically by Jules for task [9491939493638635338](https://jules.google.com/task/9491939493638635338) started by @socialawy*