### PR TITLE
feat: add export resolution selector (Closes #17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1098,12 +1098,6 @@
         "tailwindcss": "4.2.2"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
-      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
@@ -1403,12 +1397,6 @@
         "tailwindcss": "4.2.2"
       }
     },
-    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
-      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "license": "MIT"
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -1483,7 +1471,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2156,7 +2144,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {

--- a/src/composer/ExportBar.tsx
+++ b/src/composer/ExportBar.tsx
@@ -3,10 +3,12 @@
  * Export WebM button + progress bar + hardware tier badge (P3-18).
  */
 
+import { useEffect } from 'react';
 import { useProjectStore } from '../store/project';
 import { usePlaybackStore } from '../store/playback';
 import { useSettingsStore } from '../store/settings';
 import { exportAndDownload } from '../engine/exporter';
+import { getTotalDuration } from '../engine/renderer';
 
 export default function ExportBar() {
     // Individual selectors — avoids new-object-per-render Zustand bug
@@ -23,6 +25,28 @@ export default function ExportBar() {
 
     // Inline computation inside selector — NOT a function call on the store object
     const tier = useSettingsStore((s) => s.tierOverride ?? s.tier);
+    const exportResolution = useSettingsStore((s) => s.exportResolution);
+    const setExportResolution = useSettingsStore((s) => s.setExportResolution);
+
+    useEffect(() => {
+        if (!exportResolution) {
+            setExportResolution(tier === 'low' ? '720p' : '1080p');
+        } else if (tier === 'low' && exportResolution !== '720p') {
+            setExportResolution('720p');
+        } else if (tier === 'medium' && exportResolution === '4K') {
+            setExportResolution('1080p');
+        }
+    }, [tier, exportResolution, setExportResolution]);
+
+    // Default bitrate logic matches exportWebM
+    const baseBitrate = 5_000_000;
+    const duration = spec.plates.length ? getTotalDuration(spec) : 0;
+
+    let resolutionMultiplier = 1;
+    if (exportResolution === '1080p') resolutionMultiplier = 2.25; // roughly 1920x1080 / 1280x720
+    else if (exportResolution === '4K') resolutionMultiplier = 9; // roughly 3840x2160 / 1280x720
+
+    const targetBitrate = baseBitrate * resolutionMultiplier;
 
     const handleExport = async () => {
         if (!spec.plates.length || !images.length) return;
@@ -36,6 +60,8 @@ export default function ExportBar() {
 
             const imgElements = images.map((e) => e.img);
             await exportAndDownload(spec, imgElements, {
+                resolution: exportResolution || undefined,
+                bitrate: targetBitrate,
                 onProgress: (progress: number) => {
                     setExportProgress(Math.round(progress));
                 },
@@ -54,8 +80,14 @@ export default function ExportBar() {
         low: '#f87171',
     };
 
+    const is1080pDisabled = tier === 'low';
+    const is4KDisabled = tier === 'low' || tier === 'medium';
+
+    // Very rough estimation: (bitrate * multiplier) * duration_in_seconds / 8 (bits to bytes) / 1024 / 1024 (to MB)
+    const estimatedSizeMB = ((targetBitrate * duration) / 8 / 1024 / 1024).toFixed(1);
+
     return (
-        <div className="export-bar">
+        <div className="export-bar flex items-center gap-4 flex-wrap">
             {/* Save project button (P5-10) */}
             <button
                 className="btn btn--secondary"
@@ -76,6 +108,37 @@ export default function ExportBar() {
             >
                 {tier.toUpperCase()}
             </span>
+
+            <div className="export-settings flex items-center gap-2">
+                <select
+                    title="Export resolution"
+                    aria-label="Export resolution"
+                    value={exportResolution || '720p'}
+                    onChange={(e) => setExportResolution(e.target.value as '720p' | '1080p' | '4K')}
+                    disabled={isExporting}
+                    className="px-2 py-1 rounded bg-slate-800 text-white border border-slate-600 disabled:opacity-50"
+                >
+                    <option value="720p">720p (1280×720)</option>
+                    <option
+                        value="1080p"
+                        disabled={is1080pDisabled}
+                        title={is1080pDisabled ? '1080p requires Medium or High hardware tier' : ''}
+                    >
+                        1080p (1920×1080)
+                    </option>
+                    <option
+                        value="4K"
+                        disabled={is4KDisabled}
+                        title={is4KDisabled ? '4K requires High hardware tier' : ''}
+                    >
+                        4K (3840×2160)
+                    </option>
+                </select>
+
+                <span className="export-estimate text-sm text-slate-400">
+                    ~{estimatedSizeMB} MB
+                </span>
+            </div>
 
             {/* Export button (P3-14) */}
             <button

--- a/src/engine/exporter.ts
+++ b/src/engine/exporter.ts
@@ -6,6 +6,8 @@ export interface ExportOptions {
     bitrate?: number;
     /** Called each frame with progress 0→100 */
     onProgress?: (progress: number) => void;
+    /** Target resolution for export */
+    resolution?: '720p' | '1080p' | '4K';
 }
 
 /**
@@ -26,13 +28,27 @@ export async function exportWebM(
     images: HTMLImageElement[],
     options: ExportOptions = {},
 ): Promise<Blob> {
-    const { bitrate = 5_000_000, onProgress } = options;
-    const { fps, width, height } = spec.meta;
+    const { bitrate = 5_000_000, onProgress, resolution } = options;
+    const { fps } = spec.meta;
+
+    let targetWidth = spec.meta.width;
+    let targetHeight = spec.meta.height;
+
+    if (resolution === '720p') {
+        targetWidth = 1280;
+        targetHeight = 720;
+    } else if (resolution === '1080p') {
+        targetWidth = 1920;
+        targetHeight = 1080;
+    } else if (resolution === '4K') {
+        targetWidth = 3840;
+        targetHeight = 2160;
+    }
 
     // Offscreen canvas at target resolution
     const exportCanvas = document.createElement('canvas');
-    exportCanvas.width = width;
-    exportCanvas.height = height;
+    exportCanvas.width = targetWidth;
+    exportCanvas.height = targetHeight;
     const ctx = exportCanvas.getContext('2d');
     if (!ctx) throw new Error('Could not obtain 2D context for export canvas');
 

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -14,10 +14,12 @@ interface SettingsState {
     tier: HardwareTier;
     tierOverride: HardwareTier | null; // user override
     activeMode: ActiveMode;
+    exportResolution: '720p' | '1080p' | '4K' | null;
 
     setTier: (tier: HardwareTier) => void;
     setTierOverride: (tier: HardwareTier | null) => void;
     setActiveMode: (mode: ActiveMode) => void;
+    setExportResolution: (resolution: '720p' | '1080p' | '4K' | null) => void;
 
     effectiveTier: () => HardwareTier;
 }
@@ -26,10 +28,12 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     tier: 'medium',
     tierOverride: null,
     activeMode: 'compose',
+    exportResolution: null,
 
     setTier: (tier) => set({ tier }),
     setTierOverride: (tierOverride) => set({ tierOverride }),
     setActiveMode: (activeMode) => set({ activeMode }),
+    setExportResolution: (exportResolution) => set({ exportResolution }),
 
     effectiveTier: () => get().tierOverride ?? get().tier,
 }));

--- a/tests/composer/ExportBar.test.tsx
+++ b/tests/composer/ExportBar.test.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import ExportBar from '../../src/composer/ExportBar';
 import { useProjectStore } from '../../src/store/project';
 import { usePlaybackStore } from '../../src/store/playback';
+import { useSettingsStore } from '../../src/store/settings';
 import { exportAndDownload } from '../../src/engine/exporter';
 
 // Mock dependencies
@@ -34,10 +35,126 @@ describe('ExportBar', () => {
             setExportProgress: vi.fn(),
             setPlaying: vi.fn(),
         });
+
+        useSettingsStore.setState({
+            tier: 'high',
+            tierOverride: null,
+            exportResolution: null
+        });
     });
 
     afterEach(() => {
         document.body.removeChild(container);
+    });
+
+    it('sets default resolution based on tier', async () => {
+        // We test useEffect logic that depends on `tier` mapping.
+        // Note: the component itself does NOT render anything early, but let's give the effect
+        // more time and use requestAnimationFrame or longer timeout.
+
+        // --- Test 1: Low tier ---
+        useSettingsStore.setState({ tier: 'low', exportResolution: null });
+
+        const root = createRoot(container);
+        root.render(<ExportBar />);
+
+        // Poll for state update instead of guessing wait time
+        await vi.waitFor(() => {
+            expect(useSettingsStore.getState().exportResolution).toBe('720p');
+        }, { timeout: 1000 });
+
+        root.unmount();
+
+        // --- Test 2: Medium tier ---
+        useSettingsStore.setState({ tier: 'medium', exportResolution: null });
+
+        const root2 = createRoot(container);
+        root2.render(<ExportBar />);
+
+        await vi.waitFor(() => {
+            expect(useSettingsStore.getState().exportResolution).toBe('1080p');
+        }, { timeout: 1000 });
+
+        root2.unmount();
+    });
+
+    it('disables unavailable resolutions for low tier', async () => {
+        useSettingsStore.setState({ tier: 'low' });
+        const root = createRoot(container);
+        await new Promise<void>((resolve) => {
+            root.render(<ExportBar />);
+            setTimeout(resolve, 50);
+        });
+
+        const select = document.querySelector('select');
+        const options = Array.from(select!.querySelectorAll('option'));
+
+        expect(options.find(o => o.value === '720p')?.disabled).toBe(false);
+        expect(options.find(o => o.value === '1080p')?.disabled).toBe(true);
+        expect(options.find(o => o.value === '4K')?.disabled).toBe(true);
+
+        root.unmount();
+    });
+
+    it('disables unavailable resolutions for medium tier', async () => {
+        useSettingsStore.setState({ tier: 'medium' });
+        const root = createRoot(container);
+        await new Promise<void>((resolve) => {
+            root.render(<ExportBar />);
+            setTimeout(resolve, 50);
+        });
+
+        const select = document.querySelector('select');
+        const options = Array.from(select!.querySelectorAll('option'));
+
+        expect(options.find(o => o.value === '720p')?.disabled).toBe(false);
+        expect(options.find(o => o.value === '1080p')?.disabled).toBe(false);
+        expect(options.find(o => o.value === '4K')?.disabled).toBe(true);
+
+        root.unmount();
+    });
+
+    it('enables all resolutions for high tier', async () => {
+        useSettingsStore.setState({ tier: 'high' });
+        const root = createRoot(container);
+        await new Promise<void>((resolve) => {
+            root.render(<ExportBar />);
+            setTimeout(resolve, 50);
+        });
+
+        const select = document.querySelector('select');
+        const options = Array.from(select!.querySelectorAll('option'));
+
+        expect(options.find(o => o.value === '720p')?.disabled).toBe(false);
+        expect(options.find(o => o.value === '1080p')?.disabled).toBe(false);
+        expect(options.find(o => o.value === '4K')?.disabled).toBe(false);
+
+        root.unmount();
+    });
+
+    it('updates file size estimate when resolution changes', async () => {
+        const root = createRoot(container);
+        await new Promise<void>((resolve) => {
+            root.render(<ExportBar />);
+            setTimeout(resolve, 50);
+        });
+
+        useSettingsStore.getState().setExportResolution('720p');
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        const estimate720p = document.querySelector('.export-estimate')?.textContent;
+
+        useSettingsStore.getState().setExportResolution('1080p');
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        const estimate1080p = document.querySelector('.export-estimate')?.textContent;
+
+        useSettingsStore.getState().setExportResolution('4K');
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        const estimate4K = document.querySelector('.export-estimate')?.textContent;
+
+        expect(estimate720p).not.toEqual(estimate1080p);
+        expect(estimate1080p).not.toEqual(estimate4K);
+
+        root.unmount();
     });
 
     it('calls saveNow when the Save button is clicked', async () => {

--- a/tests/engine/renderer.test.ts
+++ b/tests/engine/renderer.test.ts
@@ -105,6 +105,45 @@ describe('getTotalDuration', () => {
 // ─── renderFrame tests ────────────────────────────────────────────────────────
 
 describe('renderFrame', () => {
+    it('resizes internal buffers when canvas dimensions change (Export resolution)', () => {
+        const canvas1080p = document.createElement('canvas');
+        canvas1080p.width = 1920;
+        canvas1080p.height = 1080;
+        const ctx1080p = canvas1080p.getContext('2d')!;
+
+        const canvas4k = document.createElement('canvas');
+        canvas4k.width = 3840;
+        canvas4k.height = 2160;
+        const ctx4k = canvas4k.getContext('2d')!;
+
+        const img = makeImg();
+
+        // Sequence with a composite transition to force buffer usage
+        const compSequence: Sequence = {
+            ...testSequence,
+            plates: [
+                { id: 'p1', duration: 2, effect: 'static', transition: 'cut' },
+                { id: 'p2', duration: 2, effect: 'static', transition: 'crossfade', transitionDuration: 1 },
+            ]
+        };
+
+        // Render at t=2.5 to trigger composite path
+        renderFrame(ctx1080p, canvas1080p, compSequence, [img, img], 2.5);
+
+        // Spy on drawImage to observe the buffers passed into the composite function
+        const drawSpy = vi.spyOn(ctx4k, 'drawImage');
+
+        // Render again with 4K canvas
+        renderFrame(ctx4k, canvas4k, compSequence, [img, img], 2.5);
+
+        // Expect drawImage to be called with a canvas (the buffer) that matches the 4K dimensions
+        const bufferArgs = drawSpy.mock.calls.find(call => call[0] instanceof HTMLCanvasElement);
+        expect(bufferArgs).toBeDefined();
+        const buf = bufferArgs![0] as HTMLCanvasElement;
+        expect(buf.width).toBe(3840);
+        expect(buf.height).toBe(2160);
+    });
+
     it('does not throw with valid inputs', () => {
         const canvas = makeCanvas();
         const ctx = canvas.getContext('2d')!;


### PR DESCRIPTION
Let users choose the export resolution before starting an export, with hardware tier gating.

- Add resolution dropdown in ExportBar with options: 720p, 1080p, 4K.
- Resize export offscreen canvas to match the selected resolution.
- Hardware tier gating: Low tier (720p only), Medium tier (720p + 1080p), High tier (all resolutions). Unavailable options are disabled.
- Display an estimated file size based on resolution and duration.
- Default resolution: 1080p on Medium/High tier, 720p on Low tier.

---
*PR created automatically by Jules for task [14768703165762109044](https://jules.google.com/task/14768703165762109044) started by @socialawy*